### PR TITLE
Return $DOKKU_NOT_IMPLEMENTED_EXIT when a non-existing command is called...

### DIFF
--- a/commands
+++ b/commands
@@ -227,4 +227,7 @@ case "$1" in
     volume:migrate                                                   Migrate
 EOF
     ;;
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
 esac


### PR DESCRIPTION
Please note that such return code has been introduced in dokku with the commit d307a5b8.

Thanks for considering.