### PR TITLE
Add support for dokku 0.4.0+

### DIFF
--- a/docker-args-deploy
+++ b/docker-args-deploy
@@ -1,0 +1,1 @@
+docker-args

--- a/docker-args-run
+++ b/docker-args-run
@@ -1,0 +1,1 @@
+docker-args

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,5 @@
+[plugin]
+description = "Volume (persistent storage) plugin for Dokku"
+version = "0.0.0"
+[plugin.config]
+


### PR DESCRIPTION
Based off the new plugin system for dokku 0.4.0+ http://dokku.viewdocs.io/dokku~v0.4.14/development/plugin-triggers/

This includes a symbolic linc to the newly named hooks/triggers
